### PR TITLE
Check to see whether outfile is writable before performing calculations

### DIFF
--- a/sampling.py
+++ b/sampling.py
@@ -334,6 +334,13 @@ def main(
 
     sWrite(" Done.\n")
 
+    # Make sure we can write to outfile before the heavy lifting
+    try:
+        outfile = open(outfile_name, 'w')
+    except IOError as e:
+        print('Unable to open outfile for writing:', str(e))
+        sys.exit()
+
     sWrite("Performing hit-and-run sampling...")
     if c_loaded:
         fMCSs = [
@@ -356,7 +363,6 @@ def main(
     sWrite(" Done.\n")
 
     # Save data to outfile
-    outfile = open(outfile_name, 'w')
     header = 'Run\tfMCS\t' + "\t".join(S_pd.index.values) + "\n"
     junk = outfile.write(header)
     r = 0

--- a/source/methylmalonyl_2x10x1M.sh
+++ b/source/methylmalonyl_2x10x1M.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Create output directory
+mkdir -p results/methylmalonyl_2x10x1M
+
 # Sample 10 replicates of 1 million steps in parallel at feasible delta G
 for i in {1..10}; do
   echo "./sampling.py --reactions data/methylmalonyl.model.tab \

--- a/source/methylmalonyl_2x3x100k.sh
+++ b/source/methylmalonyl_2x3x100k.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Feasible, Replicate 1
 ./sampling.py --reactions data/methylmalonyl.model.tab \
 --std_drG data/methylmalonyl.model_drGs.tab \

--- a/source/methylmalonyl_acetate.sh
+++ b/source/methylmalonyl_acetate.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Create output directory
+mkdir -p results/mmcoa_fixed_acetate
+
 # Perform MDF analysis
 ls data/mmcoa_fixed_acetate/* | while read conc_file; do
   # Extract group name (extracellular acetate concentration type)

--- a/source/methylmalonyl_fixed_prp_ac.sh
+++ b/source/methylmalonyl_fixed_prp_ac.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Create output directory
+mkdir -p results/mmcoa_fixed_prp_ac
+
 # Perform MDF analysis
 ls data/mmcoa_fixed_prp_ac/* | while read conc_file; do
   # Extract group name (extracellular acetate and propionate concentration type)

--- a/source/syntrophic_2x10x10M.high_CH4.sh
+++ b/source/syntrophic_2x10x10M.high_CH4.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Create output directory
+mkdir -p results/syntrophic_2x10x10M
+
 # Sample 10 replicates of 10 million steps in parallel at feasible delta G
 for i in {1..10}; do
   echo "./sampling.py --reactions data/syntrophic.model.tab \

--- a/source/syntrophic_2x10x10M.sh
+++ b/source/syntrophic_2x10x10M.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Create output directory
+mkdir -p results/syntrophic_2x10x10M
+
 # Sample 10 replicates of 10 million steps in parallel at feasible delta G
 for i in {1..10}; do
   echo "./sampling.py --reactions data/syntrophic.model.tab \

--- a/source/syntrophic_2x10x1M.sh
+++ b/source/syntrophic_2x10x1M.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Create output directory
+mkdir -p results/syntrophic_2x10x1M
+
 # Sample 10 replicates of 1 million steps in parallel at feasible delta G
 for i in {1..10}; do
   echo "./sampling.py --reactions data/syntrophic.model.tab \


### PR DESCRIPTION
To reduce the risk of losing work, I suggest the program should try to open outfile for writing before performing hit-and-run analysis.